### PR TITLE
Add boolean expression trees and a pycosat wrapper

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    raise AssertionError
+    raise NotImplementedError
+    if __name__ == .__main__.:

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ nosetests*.xml
 .coverage
 coverage.xml
 coverage
-.coverage*
 
 test.db
 .venv

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "2.7"
+  - "3.5"
+install: pip install tox-travis
+script: tox
+notifications:
+  email: false

--- a/pyreasoner/expressions/__init__.py
+++ b/pyreasoner/expressions/__init__.py
@@ -8,6 +8,7 @@ import operator
 
 from six import with_metaclass
 
+
 class Evaluable(with_metaclass(abc.ABCMeta)):
     @abc.abstractmethod
     def eval(self, namespace):
@@ -19,6 +20,7 @@ def eval_expr(expr, namespace):
         return expr.eval(namespace)
     else:
         return expr
+
 
 def variables(names):
     if not isinstance(input, (list, tuple)):
@@ -65,6 +67,7 @@ def convert_to_conjunctive_normal_form(expr):
             (convert_to_conjunctive_normal_form(child) for child in expr.children))
     else:
         return expr
+
 
 class ExpressionNode(object):
     def __or__(self, other):

--- a/pyreasoner/expressions/__init__.py
+++ b/pyreasoner/expressions/__init__.py
@@ -105,8 +105,14 @@ class ExpressionNode(with_metaclass(abc.ABCMeta)):
     def __or__(self, other):
         return Or(self, other)
 
+    def __ror__(self, other):
+        return Or(other, self)
+
     def __and__(self, other):
         return And(self, other)
+
+    def __rand__(self, other):
+        return And(other, self)
 
     def __invert__(self):
         return Not(self)
@@ -196,6 +202,12 @@ class Or(BooleanOperation):
         else:
             return Or(*chain(self.children, [other]))
 
+    def __ror__(self, other):
+        if isinstance(other, Or):
+            return Or(*chain(other.children, self.children))
+        else:
+            return Or(*chain([other], self.children))
+
     def recursive_collapse(self):
         """
         Returns an Or node whose Or children have been promoted to the top level
@@ -223,6 +235,12 @@ class And(BooleanOperation):
             return And(*chain(self.children, other.children))
         else:
             return And(*chain(self.children, [other]))
+
+    def __rand__(self, other):
+        if isinstance(other, And):
+            return And(*chain(other.children, self.children))
+        else:
+            return And(*chain([other], self.children))
 
 
 class Not(BooleanOperation):

--- a/pyreasoner/expressions/__init__.py
+++ b/pyreasoner/expressions/__init__.py
@@ -92,16 +92,15 @@ def convert_to_conjunctive_normal_form(expr):
 class ExpressionNode(with_metaclass(abc.ABCMeta)):
 
     @abc.abstractmethod
-    def eval(self, namespace):
+    def eval(self, namespace):  # pragma: no cover
         raise NotImplementedError
 
     @abc.abstractmethod
-    def reify(self, namespace):
+    def reify(self, namespace):  # pragma: no cover
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_free_variables(self):
-
+    def get_free_variables(self):  # pragma: no cover
         raise NotImplementedError
 
     def __or__(self, other):

--- a/pyreasoner/expressions/__init__.py
+++ b/pyreasoner/expressions/__init__.py
@@ -275,3 +275,7 @@ def get_truth_table(expr):
         assignment: expr.eval({var: value for var, value in zip(variables, assignment)})
         for assignment in itertools.product(*([bools] * len(variables)))
     }
+
+
+def is_logically_equivalent(expr1, expr2):
+    return get_free_variables(expr1) == get_free_variables(expr2)

--- a/pyreasoner/expressions/__init__.py
+++ b/pyreasoner/expressions/__init__.py
@@ -11,6 +11,8 @@ import pycosat
 
 from six import with_metaclass
 
+from ..utils import is_valid_identifier
+
 
 def eval_expr(expr, namespace):
     if isinstance(expr, ExpressionNode):
@@ -125,6 +127,8 @@ class Var(ExpressionNode):
     def __init__(self, name=None):
         if name is None:
             name = 'x_%s' % id(self)
+        if not is_valid_identifier(name):
+            raise ValueError('%r is an invalid identifier' % name)
         self.name = name
 
     def reify(self, namespace):

--- a/pyreasoner/expressions/__init__.py
+++ b/pyreasoner/expressions/__init__.py
@@ -205,7 +205,7 @@ class Or(BooleanOperation):
             return Or(*chain(self.children, [other]))
 
     def __ror__(self, other):
-        return Or(*chain([other], self.children))
+        return Or(other, *self.children)
 
     def recursive_collapse(self):
         """
@@ -236,7 +236,7 @@ class And(BooleanOperation):
             return And(*chain(self.children, [other]))
 
     def __rand__(self, other):
-        return And(*chain([other], self.children))
+        return And(other, *self.children)
 
 
 class Not(BooleanOperation):

--- a/pyreasoner/expressions/__init__.py
+++ b/pyreasoner/expressions/__init__.py
@@ -306,21 +306,17 @@ def solve_SAT(expr, num_solutions=None):
     Returns a iterator of {var: truth value} assignments which satisfy the given
     expression.
 
-    Expressions should not include a variable named ``__TRUE__`` or ``__FALSE__``,
-    since those are used in the internals of this function as stand-ins for
-    truth literals.
+    Expressions should not include a variable named ``__TRUE__``, since those
+    are used in the internals of this function as stand-ins for truth literals.
     """
     expr = convert_to_conjunctive_normal_form(expr)
 
-    # Hack to include truth literals (not supported by pycosat API.
-    # Trivial constraints are added to the list of constraints forcing these variables
-    # to be True/False in any solutions.
+    # Hack to include a True literal (not directly supported by pycosat API).
+    # We add a trivial constraint to the list of constraints, forcing this
+    # variables to be True in any solutions. Note that this is still conjunctive
+    # normal form, since T and F are literals.
     T = Var('__TRUE__')
-    F = Var('__FALSE__')
-
-    # This forces the variable T to be True, and F to be False. Note that this is still
-    # conjunctive normal form, since T and F are literals.
-    expr = expr & T & ~F
+    expr = expr & T
 
     vars = list(get_free_variables(expr))
 
@@ -359,9 +355,8 @@ def solve_SAT(expr, num_solutions=None):
             # to True, and negative corresponds to False.
             as_bool = var_assignment > 0
             var = vars[i]
-            if var in (T, F):
-                assert as_bool == (var == T), \
-                    'Bug: Solution has an invalid solution to the T/F literals.'
+            if var == T:
+                assert as_bool, 'Bug: Solution has an invalid solution to the T literal.'
             else:
                 namespace[var] = as_bool
         yield namespace

--- a/pyreasoner/expressions/__init__.py
+++ b/pyreasoner/expressions/__init__.py
@@ -1,0 +1,186 @@
+from __future__ import division, absolute_import, unicode_literals
+
+import abc
+from functools import reduce
+from itertools import chain
+import re
+import operator
+
+from six import with_metaclass
+
+class Evaluable(with_metaclass(abc.ABCMeta)):
+    @abc.abstractmethod
+    def eval(self, namespace):
+        pass
+
+
+def eval_expr(expr, namespace):
+    if isinstance(expr, Evaluable):
+        return expr.eval(namespace)
+    else:
+        return expr
+
+def variables(names):
+    if not isinstance(input, (list, tuple)):
+        names = re.split(r'[, ]', names)
+    return map(Var, names)
+
+
+def is_boolean_atom(obj):
+    return isinstance(obj, (Not, Var, bool))
+
+
+def is_disjunction_of_atoms(expr):
+    return is_boolean_atom(expr) or (
+        isinstance(expr, Or) and
+        all(is_boolean_atom(child) for child in expr.children))
+
+
+def is_conjunctive_normal_form(expr):
+    if is_boolean_atom(expr):
+        return True
+    return is_disjunction_of_atoms(expr) or (
+        isinstance(expr, And) and
+        all(is_disjunction_of_atoms(child) for child in expr.children)
+    )
+
+
+def convert_to_conjunctive_normal_form(expr):
+    if is_disjunction_of_atoms(expr):
+        return expr
+    elif isinstance(expr, Not):
+        return convert_to_conjunctive_normal_form(expr.distribute_inwards())
+    elif isinstance(expr, Or):
+        if len(expr.children) == 1:
+            return expr.children[0]
+        split = len(expr.children // 2)
+        left, right = expr.children[:split], expr.children[split:]
+        return convert_to_conjunctive_normal_form(
+            And(*(Not(child).distribute_inwards() for child in left))
+            & And(*(Not(child).distribute_inwards() for child in right))
+        )
+    elif isinstance(expr, And):
+        return reduce(
+            operator.and_,
+            (convert_to_conjunctive_normal_form(child) for child in expr.children))
+    else:
+        return expr
+
+class ExpressionNode(object):
+    def __or__(self, other):
+        return Or(self, other)
+
+    def __and__(self, other):
+        return And(self, other)
+
+    def __invert__(self):
+        return Not(self)
+
+
+class Var(ExpressionNode):
+    __slots__ = ('name', )
+
+    def __init__(self, name=None):
+        if name is None:
+            name = 'x_%s' % id(self)
+        self.name = name
+
+    def eval(self, namespace):
+        if self in namespace:
+            return namespace[self]
+        elif self.name in namespace:
+            return namespace[self.name]
+        return self
+
+    def __str__(self):
+        return self.name
+
+    __repr__ = __str__
+
+    def __hash__(self):
+        return hash(self.name)
+
+    def __eq__(self, other):
+        return self.name == other.name
+
+
+class BooleanOperation(ExpressionNode):
+    __slots__ = ('children', )
+
+    def __init__(self, *children):
+        self.children = children
+
+    def eval(self, namespace):
+        evaluated = [eval_expr(child, namespace) for child in self.children]
+        if hasattr(self, 'default'):
+            return reduce(self.operator, evaluated, self.default)
+        return reduce(self.operator, evaluated)
+
+    def __eq__(self, other):
+        return type(self) == type(other) and self.children == other.children
+
+
+class Or(BooleanOperation):
+    operator = operator.or_
+
+    def __str__(self):
+        return '(%s)' % ' | '.join(str(child) for child in self.children)
+
+    __repr__ = __str__
+
+    def __or__(self, other):
+        if isinstance(other, Or):
+            return Or(*chain(self.children, other.children))
+        else:
+            return Or(*chain(self.children, [other]))
+
+
+class And(BooleanOperation):
+    operator = operator.and_
+
+    def __str__(self):
+        return '(%s)' % ' & '.join(str(child) for child in self.children)
+
+    __repr__ = __str__
+
+    def __and__(self, other):
+        if isinstance(other, And):
+            return And(*chain(self.children, other.children))
+        else:
+            return And(*chain(self.children, [other]))
+
+
+class Not(BooleanOperation):
+    def __init__(self, child):
+        self.children = (child, )
+
+    def eval(self, namespace):
+        evaluated = eval_expr(self.children[0], namespace)
+        if isinstance(evaluated, ExpressionNode):
+            return ~evaluated
+        elif isinstance(evaluated, bool):
+            # Boolean
+            return not evaluated
+        else:
+            raise TypeError(evaluated)
+
+    def __str__(self):
+        return '~%s' % self.children[0]
+
+    __repr__ = __str__
+
+    def distribute_inwards(self):
+        child = self.children[0]
+        if isinstance(child, bool):
+            return not child
+        elif isinstance(child, Not):
+            # Simplify double negation.
+            return child.children[0]
+        elif isinstance(child, Or):
+            # Instance of de Morgan's Law: ~(x | y) === (~x & ~y)
+            return And(*(Not(descendant).distribute_inwards() for descendant in child.children))
+        elif isinstance(child, And):
+            # Instance of de Morgan's Law: ~(x & y) === (~x | ~y)
+            return Or(*(Not(descendant).distribute_inwards() for descendant in child.children))
+        else:
+            return self

--- a/pyreasoner/expressions/__init__.py
+++ b/pyreasoner/expressions/__init__.py
@@ -77,7 +77,7 @@ def convert_to_conjunctive_normal_form(expr):
             operator.and_,
             (convert_to_conjunctive_normal_form(child) for child in expr.children),
             And())
-    else:  # pragma:nocover
+    else:  # pragma: no cover
         assert False, 'Unhandled: %r' % expr
 
 
@@ -230,7 +230,7 @@ class Not(BooleanOperation):
         elif isinstance(evaluated, bool):
             # Boolean
             return not evaluated
-        else:  # pragma:nocover
+        else:  # pragma: no cover
             raise TypeError(evaluated)
 
     def get_free_variables(self):
@@ -319,7 +319,7 @@ def solve_SAT(expr, num_solutions=None):
             return -var2pycosat_index[literal.children[0]]
         elif isinstance(literal, Var):
             return var2pycosat_index[literal]
-        elif isinstance(literal, ExpressionNode):
+        elif isinstance(literal, ExpressionNode):  # pragma: no cover
             raise TypeError('Unhandled literal type %r' % literal)
         else:
             # Here we assume this is some other python object, so we consider it

--- a/pyreasoner/expressions/__init__.py
+++ b/pyreasoner/expressions/__init__.py
@@ -114,15 +114,18 @@ class Var(ExpressionNode):
         self.name = name
 
     def reify(self, namespace):
+        """
+        Replace with the assignment in ``namespace``.
+
+        Note that this does not follow chained a->b->c namespace substitutions
+        as ``eval`` does.
+        """
         if self in namespace:
             ret = namespace[self]
         elif self.name in namespace:
             ret = namespace[self.name]
         else:
             ret = self
-        if ret != self:
-            # Note this can lead to infinite recursion, e.g. ``x.reify({x: y, y: x})``.
-            ret = reify_expr(ret, namespace)
         return ret
 
     def eval(self, namespace):
@@ -226,7 +229,7 @@ class Not(BooleanOperation):
         elif isinstance(evaluated, bool):
             # Boolean
             return not evaluated
-        else: # pragma:nocover
+        else:  # pragma:nocover
             raise TypeError(evaluated)
 
     def get_free_variables(self):

--- a/pyreasoner/expressions/__init__.py
+++ b/pyreasoner/expressions/__init__.py
@@ -76,8 +76,8 @@ def convert_to_conjunctive_normal_form(expr):
             operator.and_,
             (convert_to_conjunctive_normal_form(child) for child in expr.children),
             And())
-    else:
-        return expr
+    else:  # pragma:nocover
+        assert False, 'Unhandled: %r' % expr
 
 
 class ExpressionNode(with_metaclass(abc.ABCMeta)):
@@ -226,7 +226,7 @@ class Not(BooleanOperation):
         elif isinstance(evaluated, bool):
             # Boolean
             return not evaluated
-        else:
+        else: # pragma:nocover
             raise TypeError(evaluated)
 
     def get_free_variables(self):

--- a/pyreasoner/expressions/__init__.py
+++ b/pyreasoner/expressions/__init__.py
@@ -71,8 +71,10 @@ def _convert_to_conjunctive_normal_form(expr):
                 result = _convert_to_conjunctive_normal_form(
                     And(*(descendant | other_disjuncts for descendant in child.children)))
                 return result
-        else:
-            assert False, expr
+        else:  # pragma: no cover
+            # This branch would indicate a bug in recursive_collapse or
+            # is_disjunction_of_atoms.
+            assert False, 'Bug: Should be unreachable: %r' % expr
     elif isinstance(expr, And):
         return reduce(
             operator.and_,
@@ -203,10 +205,7 @@ class Or(BooleanOperation):
             return Or(*chain(self.children, [other]))
 
     def __ror__(self, other):
-        if isinstance(other, Or):
-            return Or(*chain(other.children, self.children))
-        else:
-            return Or(*chain([other], self.children))
+        return Or(*chain([other], self.children))
 
     def recursive_collapse(self):
         """
@@ -237,10 +236,7 @@ class And(BooleanOperation):
             return And(*chain(self.children, [other]))
 
     def __rand__(self, other):
-        if isinstance(other, And):
-            return And(*chain(other.children, self.children))
-        else:
-            return And(*chain([other], self.children))
+        return And(*chain([other], self.children))
 
 
 class Not(BooleanOperation):

--- a/pyreasoner/expressions/__init__.py
+++ b/pyreasoner/expressions/__init__.py
@@ -27,9 +27,9 @@ def reify_expr(expr, namespace):
 
 
 def variables(names):
-    if not isinstance(input, (list, tuple)):
-        names = re.split(r'[, ]', names)
-    return map(Var, names)
+    if not isinstance(names, (list, tuple)):
+        names = re.split(r'[, ]+', names)
+    return [Var(name) for name in names]
 
 
 def is_boolean_atom(obj):

--- a/pyreasoner/expressions/__init__.py
+++ b/pyreasoner/expressions/__init__.py
@@ -48,19 +48,18 @@ def is_conjunctive_normal_form(expr):
 
 
 def convert_to_conjunctive_normal_form(expr):
+    """
+    Dumb conjunctive normal form algorithm based off this algorithm:
+    https://april.eecs.umich.edu/courses/eecs492_w10/wiki/images/6/6b/CNF_conversion.pdf
+    """
     if is_disjunction_of_atoms(expr):
         return expr
     elif isinstance(expr, Not):
         return convert_to_conjunctive_normal_form(expr.distribute_inwards())
     elif isinstance(expr, Or):
-        if len(expr.children) == 1:
-            return expr.children[0]
-        split = len(expr.children // 2)
-        left, right = expr.children[:split], expr.children[split:]
-        return convert_to_conjunctive_normal_form(
-            And(*(Not(child).distribute_inwards() for child in left))
-            & And(*(Not(child).distribute_inwards() for child in right))
-        )
+        return reduce(
+            operator.and_
+            (convert_to_conjunctive_normal_form(Not(child)) for child in expr.children))
     elif isinstance(expr, And):
         return reduce(
             operator.and_,

--- a/pyreasoner/expressions/__init__.py
+++ b/pyreasoner/expressions/__init__.py
@@ -1,10 +1,10 @@
-from __future__ import division, absolute_import, unicode_literals
+from __future__ import absolute_import, division, unicode_literals
 
 import abc
+import operator
+import re
 from functools import reduce
 from itertools import chain
-import re
-import operator
 
 from six import with_metaclass
 

--- a/pyreasoner/tests/__init__.py
+++ b/pyreasoner/tests/__init__.py
@@ -1,7 +1,11 @@
 from unittest import TestCase
 
+from ..expressions import And
 from ..expressions import convert_to_conjunctive_normal_form
+from ..expressions import get_free_variables
+from ..expressions import get_truth_table
 from ..expressions import is_conjunctive_normal_form
+from ..expressions import Or
 from ..expressions import variables
 
 a, b, c, d, e = variables('a b c d e')
@@ -37,3 +41,39 @@ class TestConjunctiveNormalForm(TestCase):
             self.assertEqual(
                 convert_to_conjunctive_normal_form(expr),
                 solution)
+
+
+class TestGetFreeVariables(TestCase):
+    def test(self):
+        self.assertEqual(get_free_variables(a), {a})
+        self.assertEqual(get_free_variables(~a), {a})
+        self.assertEqual(get_free_variables(a | a), {a})
+        self.assertEqual(get_free_variables(a & a), {a})
+        self.assertEqual(get_free_variables(a & b), {a, b})
+        self.assertEqual(get_free_variables(~(a & b)), {a, b})
+        self.assertEqual(get_free_variables(~(a | b)), {a, b})
+
+
+class TestTruthTable(TestCase):
+    def test_and(self):
+        and_table = {
+            (b1, b2): b1 and b2
+            for b1, b2 in [(True, True), (True, False), (False, True), (False, False)]
+        }
+
+        self.assertEqual(get_truth_table(a & b), and_table)
+
+    def test_or(self):
+        or_table = {
+            (b1, b2): b1 or b2
+            for b1, b2 in [(True, True), (True, False), (False, True), (False, False)]
+        }
+
+        self.assertEqual(get_truth_table(a | b), or_table)
+
+    def test_negation(self):
+        self.assertEqual(get_truth_table(~a), {(True, ): False, (False, ): True})
+
+    def test_no_free_variables(self):
+        self.assertEqual(get_truth_table(Or(True, False)), {(): True})
+        self.assertEqual(get_truth_table(And(True, False)), {(): False})

--- a/pyreasoner/tests/__init__.py
+++ b/pyreasoner/tests/__init__.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
-from ..expressions import is_conjunctive_normal_form
 from ..expressions import convert_to_conjunctive_normal_form
+from ..expressions import is_conjunctive_normal_form
 from ..expressions import variables
 
 a, b, c, d, e = variables('a b c d e')

--- a/pyreasoner/tests/__init__.py
+++ b/pyreasoner/tests/__init__.py
@@ -1,3 +1,4 @@
+import operator
 from unittest import TestCase
 
 from nose.tools import assert_true
@@ -87,6 +88,17 @@ class TestTruthTable(TestCase):
     def test_no_free_variables(self):
         self.assertEqual(get_truth_table(Or(True, False)), {(): True})
         self.assertEqual(get_truth_table(And(True, False)), {(): False})
+
+    def test_truth_table_and_reification(self):
+        for expr in CNF_EXPRESSIONS:
+            table = get_truth_table(expr)
+            vars = sorted(get_free_variables(expr), key=operator.attrgetter('name'))
+            self.assertEqual(2 ** len(vars), len(table))
+            for assignment, value in table.items():
+                self.assertEqual(len(vars), len(assignment))
+                namespace = dict(zip(vars, assignment))
+                self.assertEqual(expr.reify(namespace).eval({}), expr.eval(namespace))
+                self.assertEqual(expr.reify(namespace).eval({}), value)
 
 
 class TestReify(TestCase):

--- a/pyreasoner/tests/__init__.py
+++ b/pyreasoner/tests/__init__.py
@@ -5,6 +5,7 @@ from ..expressions import convert_to_conjunctive_normal_form
 from ..expressions import get_free_variables
 from ..expressions import get_truth_table
 from ..expressions import is_conjunctive_normal_form
+from ..expressions import Not
 from ..expressions import Or
 from ..expressions import variables
 
@@ -77,3 +78,19 @@ class TestTruthTable(TestCase):
     def test_no_free_variables(self):
         self.assertEqual(get_truth_table(Or(True, False)), {(): True})
         self.assertEqual(get_truth_table(And(True, False)), {(): False})
+
+
+class TestReify(TestCase):
+    def test_chained_evaluation(self):
+        self.assertEqual(a.reify({a: b, b: c}), c)
+        self.assertEqual(a.reify({b: c}), a)
+
+    def test_or(self):
+        self.assertEqual((a | c).reify({c: a}), a | a)
+
+    def test_and(self):
+        self.assertEqual((a & c).reify({c: a}), a & a)
+
+    def test_negation(self):
+        self.assertEqual((~a).reify({a: False}), Not(False))
+        self.assertEqual((~a).reify({c: a}), ~a)

--- a/pyreasoner/tests/__init__.py
+++ b/pyreasoner/tests/__init__.py
@@ -43,6 +43,11 @@ class TestConstructVariables(TestCase):
         self.assertEqual(variables('a b c'), [a, b, c])
         self.assertEqual(variables(['a', 'b', 'c']), [a, b, c])
         self.assertTrue(Var().name)
+        with self.assertRaises(ValueError):
+            Var('not$a$variable')
+
+        with self.assertRaises(ValueError):
+            Var('in')  # builtin
 
 
 class TestExpressionBooleanOperations(TestCase):

--- a/pyreasoner/tests/__init__.py
+++ b/pyreasoner/tests/__init__.py
@@ -36,6 +36,13 @@ def assert_logically_equivalent(expr1, expr2):
         '%r is not logically equivalent to %r' % (expr1, expr2))
 
 
+class TestConstructVariables(TestCase):
+    def test(self):
+        self.assertEqual(variables('a b c'), variables('a, b, c'))
+        self.assertEqual(variables('a b c'), [a, b, c])
+        self.assertEqual(variables(['a', 'b', 'c']), [a, b, c])
+
+
 class TestExpressionBooleanOperations(TestCase):
     def test_operations(self):
         self.assertEqual(a & True, And(a, True))
@@ -69,6 +76,10 @@ class TestConjunctiveNormalForm(TestCase):
             assert_logically_equivalent(
                 convert_to_conjunctive_normal_form(expr),
                 solution)
+
+    def test_empty_expressions(self):
+        self.assertEqual(convert_to_conjunctive_normal_form(Or()), And(Or()))
+        self.assertEqual(convert_to_conjunctive_normal_form(And()), And())
 
 
 class TestGetFreeVariables(TestCase):
@@ -126,6 +137,9 @@ class TestReify(TestCase):
 
     def test_or(self):
         self.assertEqual((a | c).reify({c: a}), a | a)
+
+    def test_reify_including_truth_literal(self):
+        self.assertEqual((a | True).reify({a: False}), Or(False, True))
 
     def test_and(self):
         self.assertEqual((a & c).reify({c: a}), a & a)

--- a/pyreasoner/tests/__init__.py
+++ b/pyreasoner/tests/__init__.py
@@ -168,3 +168,10 @@ class TestSAT(TestCase):
         all_solutions = list(solve_SAT(expr))
         self.assertIn(expected_solution, all_solutions)
         self.assertEqual(len(all_solutions), 9)
+
+    def test_expression_with_literal(self):
+        self.assertTrue(is_satisfiable(True))
+        self.assertEqual(list(solve_SAT(True)), [{}])
+        self.assertFalse(is_satisfiable(False))
+        self.assertTrue(is_satisfiable(Or(True, False, a)))
+        self.assertFalse(is_satisfiable(And(True, False, a)))

--- a/pyreasoner/tests/__init__.py
+++ b/pyreasoner/tests/__init__.py
@@ -36,6 +36,21 @@ def assert_logically_equivalent(expr1, expr2):
         '%r is not logically equivalent to %r' % (expr1, expr2))
 
 
+class TestExpressionBooleanOperations(TestCase):
+    def test_operations(self):
+        self.assertEqual(a & True, And(a, True))
+        self.assertEqual(a | True, Or(a, True))
+        self.assertEqual(Or(a, b) | Or(c, d), Or(a, b, c, d))
+        self.assertEqual(And(a, b) & And(c, d), And(a, b, c, d))
+        self.assertEqual(And(a, b) | And(c, d), Or(a & b, c & d))
+
+    def test_reverse_operations(self):
+        self.assertEqual(a & True, And(a, True))
+        self.assertEqual(True & a, And(True, a))
+        self.assertEqual(a | True, Or(a, True))
+        self.assertEqual(True | a, Or(True, a))
+
+
 class TestConjunctiveNormalForm(TestCase):
     def test_cnf_expressions(self):
         for cnf_expression in CNF_EXPRESSIONS:

--- a/pyreasoner/tests/__init__.py
+++ b/pyreasoner/tests/__init__.py
@@ -6,20 +6,34 @@ from ..expressions import variables
 
 a, b, c, d, e = variables('a b c d e')
 
-cnf_expressions = (
+CNF_EXPRESSIONS = (
     ~a & (b | c),
     (a | b) & (~b | c | ~d) & (d | e),
     a | b,
     a & b
 )
+NON_CNF_EXPRESSIONS_WITH_SOLUTIONS = (
+    (~(b | c), ~b & ~c),
+    ((a & b) | c, (a | c) & (b | c)),
+    (a & ((b | (d & e))), a & (b | d) & (b | e)),
+)
 
 
 class TestConjunctiveNormalForm(TestCase):
     def test_cnf_expressions(self):
-        for cnf_expression in cnf_expressions:
+        for cnf_expression in CNF_EXPRESSIONS:
             self.assertTrue(
                 is_conjunctive_normal_form(cnf_expression),
                 cnf_expression)
             self.assertEqual(
                 convert_to_conjunctive_normal_form(cnf_expression),
                 cnf_expression)
+
+    def test_non_cnf_expressions(self):
+        for expr, solution in NON_CNF_EXPRESSIONS_WITH_SOLUTIONS:
+            self.assertFalse(
+                is_conjunctive_normal_form(expr),
+                expr)
+            self.assertEqual(
+                convert_to_conjunctive_normal_form(expr),
+                solution)

--- a/pyreasoner/tests/__init__.py
+++ b/pyreasoner/tests/__init__.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 
 from ..expressions import is_conjunctive_normal_form
 from ..expressions import convert_to_conjunctive_normal_form
+from ..expressions import variables
 
 a, b, c, d, e = variables('a b c d e')
 

--- a/pyreasoner/tests/__init__.py
+++ b/pyreasoner/tests/__init__.py
@@ -1,0 +1,24 @@
+from unittest import TestCase
+
+from ..expressions import is_conjunctive_normal_form
+from ..expressions import convert_to_conjunctive_normal_form
+
+a, b, c, d, e = variables('a b c d e')
+
+cnf_expressions = (
+    ~a & (b | c),
+    (a | b) & (~b | c | ~d) & (d | e),
+    a | b,
+    a & b
+)
+
+
+class TestConjunctiveNormalForm(TestCase):
+    def test_cnf_expressions(self):
+        for cnf_expression in cnf_expressions:
+            self.assertTrue(
+                is_conjunctive_normal_form(cnf_expression),
+                cnf_expression)
+            self.assertEqual(
+                convert_to_conjunctive_normal_form(cnf_expression),
+                cnf_expression)

--- a/pyreasoner/tests/__init__.py
+++ b/pyreasoner/tests/__init__.py
@@ -1,12 +1,15 @@
 from unittest import TestCase
 
+from nose.tools import assert_true
+
 from ..expressions import And
+from ..expressions import Not
+from ..expressions import Or
 from ..expressions import convert_to_conjunctive_normal_form
 from ..expressions import get_free_variables
 from ..expressions import get_truth_table
 from ..expressions import is_conjunctive_normal_form
-from ..expressions import Not
-from ..expressions import Or
+from ..expressions import is_logically_equivalent
 from ..expressions import variables
 
 a, b, c, d, e = variables('a b c d e')
@@ -24,13 +27,19 @@ NON_CNF_EXPRESSIONS_WITH_SOLUTIONS = (
 )
 
 
+def assert_logically_equivalent(expr1, expr2):
+    assert_true(
+        is_logically_equivalent(expr1, expr2),
+        '%r is not logically equivalent to %r' % (expr1, expr2))
+
+
 class TestConjunctiveNormalForm(TestCase):
     def test_cnf_expressions(self):
         for cnf_expression in CNF_EXPRESSIONS:
             self.assertTrue(
                 is_conjunctive_normal_form(cnf_expression),
                 cnf_expression)
-            self.assertEqual(
+            assert_logically_equivalent(
                 convert_to_conjunctive_normal_form(cnf_expression),
                 cnf_expression)
 
@@ -39,7 +48,7 @@ class TestConjunctiveNormalForm(TestCase):
             self.assertFalse(
                 is_conjunctive_normal_form(expr),
                 expr)
-            self.assertEqual(
+            assert_logically_equivalent(
                 convert_to_conjunctive_normal_form(expr),
                 solution)
 

--- a/pyreasoner/tests/__init__.py
+++ b/pyreasoner/tests/__init__.py
@@ -6,6 +6,7 @@ from nose.tools import assert_true
 from ..expressions import And
 from ..expressions import Not
 from ..expressions import Or
+from ..expressions import Var
 from ..expressions import convert_to_conjunctive_normal_form
 from ..expressions import get_free_variables
 from ..expressions import get_truth_table
@@ -41,6 +42,7 @@ class TestConstructVariables(TestCase):
         self.assertEqual(variables('a b c'), variables('a, b, c'))
         self.assertEqual(variables('a b c'), [a, b, c])
         self.assertEqual(variables(['a', 'b', 'c']), [a, b, c])
+        self.assertTrue(Var().name)
 
 
 class TestExpressionBooleanOperations(TestCase):
@@ -56,6 +58,11 @@ class TestExpressionBooleanOperations(TestCase):
         self.assertEqual(True & a, And(True, a))
         self.assertEqual(a | True, Or(a, True))
         self.assertEqual(True | a, Or(True, a))
+
+    def test_distribute_inwards(self):
+        self.assertEqual(Not(False).distribute_inwards(), True)
+        self.assertEqual(Not(a & b).distribute_inwards(), ~a | ~b)
+        self.assertEqual(Not(a | b).distribute_inwards(), ~a & ~b)
 
 
 class TestConjunctiveNormalForm(TestCase):

--- a/pyreasoner/tests/__init__.py
+++ b/pyreasoner/tests/__init__.py
@@ -103,7 +103,8 @@ class TestTruthTable(TestCase):
 
 class TestReify(TestCase):
     def test_chained_evaluation(self):
-        self.assertEqual(a.reify({a: b, b: c}), c)
+        self.assertEqual(a.reify({a: b, b: c}), b)
+        self.assertEqual(a.eval({a: b, b: 1}), 1)
         self.assertEqual(a.reify({b: c}), a)
 
     def test_or(self):
@@ -115,3 +116,18 @@ class TestReify(TestCase):
     def test_negation(self):
         self.assertEqual((~a).reify({a: False}), Not(False))
         self.assertEqual((~a).reify({c: a}), ~a)
+
+    def test_idempotency_with_empty_namespace(self):
+        for expr in CNF_EXPRESSIONS:
+            self.assertEqual(expr.reify({}), expr)
+
+    def test_permutation_of_variables(self):
+        for expr in CNF_EXPRESSIONS:
+            vars = list(get_free_variables(expr))
+            perm = vars[1:] + [vars[0]]
+            self.assertNotEqual(vars, perm)
+            assignment = dict(zip(vars, perm))
+            reverse_assignment = dict(zip(perm, vars))
+            self.assertNotEqual(expr.reify(assignment), expr)
+            self.assertEqual(expr.reify(assignment).reify(reverse_assignment), expr)
+            self.assertEqual(expr.reify(reverse_assignment).reify(assignment), expr)

--- a/pyreasoner/utils.py
+++ b/pyreasoner/utils.py
@@ -7,5 +7,8 @@ import six
 isidentifier = str.isidentifier if six.PY3 else re.compile('^%s$' % tokenize.Name).match
 
 
-def is_valid_identifier(name):
-    return not keyword.iskeyword(name) and isidentifier(name)
+def is_valid_identifier_for_namedtuple(name):
+    return (
+        not name.startswith('_') and  # _names are disallowed by namedtuple
+        not keyword.iskeyword(name) and
+        isidentifier(name))

--- a/pyreasoner/utils.py
+++ b/pyreasoner/utils.py
@@ -1,0 +1,11 @@
+import keyword
+import re
+import tokenize
+
+import six
+
+isidentifier = str.isidentifier if six.PY3 else re.compile('^%s$' % tokenize.Name).match
+
+
+def is_valid_identifier(name):
+    return not keyword.iskeyword(name) and isidentifier(name)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,5 @@ flake8==2.4.1
 mock==1.3.0
 nose
 pycosat
+typing
+six

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,8 @@
 # Requirements needed for running the test suite.
 
 coverage
-flake8==2.4.1
 mock==1.3.0
 nose
 pycosat
 typing
 six
-flake8-import-order

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ nose
 pycosat
 typing
 six
+flake8-import-order

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ nose
 pycosat
 typing
 six
+ipython

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,2 +1,4 @@
 flake8==2.4.1
 flake8-import-order
+flake8-debugger
+flake8-print

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,0 +1,2 @@
+flake8==2.4.1
+flake8-import-order

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ indexserver =
     default = https://pypi.python.org/simple
 
 [tox:travis]
-  2.7 = py27
-  3.5 = py35, lint
+2.7 = py27
+3.5 = py35, lint
 
 [testenv]
 usedevelop = True

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ whitelist_externals = rm
 
 [testenv:lint]
 commands =
-    lint: flake8 pyreasoner
+    lint: flake8 --import-order-style=cryptography pyreasoner
 
 [flake8]
 ignore = W503

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 install_command = pip install {opts} {packages}
 envlist = py27,py35,lint
+indexserver =
+    default = https://pypi.python.org/simple
 
 [testenv]
 usedevelop = True
@@ -13,6 +15,7 @@ basepython =
     lint: python3.5
 deps =
     -r{toxinidir}/requirements-dev.txt
+    -r{toxinidir}/requirements-lint.txt
 whitelist_externals = rm
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,8 @@ whitelist_externals = rm
 [testenv:lint]
 commands =
     lint: flake8 --import-order-style=cryptography pyreasoner
+deps =
+    -r{toxinidir}/requirements-lint.txt
 
 [flake8]
 ignore = W503

--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,6 @@ usedevelop = True
 commands =
     rm -f .coverage
     nosetests --with-coverage {posargs:pyreasoner}
-
-[testenv:lint]
-commands =
-    lint: flake8 pyreasoner
 basepython =
     py27: python2.7
     py35: python3.5
@@ -18,6 +14,10 @@ basepython =
 deps =
     -r{toxinidir}/requirements-dev.txt
 whitelist_externals = rm
+
+[testenv:lint]
+commands =
+    lint: flake8 pyreasoner
 
 [flake8]
 ignore = W503

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ whitelist_externals = rm
 
 [testenv:lint]
 commands =
-    lint: flake8 --import-order-style=cryptography pyreasoner
+    flake8 --import-order-style=cryptography pyreasoner
 deps =
     -r{toxinidir}/requirements-lint.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ usedevelop = True
 commands =
     rm -f .coverage
     nosetests --with-coverage {posargs:pyreasoner}
+
 [testenv:lint]
 commands =
     lint: flake8 pyreasoner
@@ -17,3 +18,7 @@ basepython =
 deps =
     -r{toxinidir}/requirements-dev.txt
 whitelist_externals = rm
+
+[flake8]
+ignore = W503
+max-line-length = 100

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,10 @@ envlist = py27,py35,lint
 indexserver =
     default = https://pypi.python.org/simple
 
+[tox:travis]
+  2.7 = py27
+  3.5 = py35, lint
+
 [testenv]
 usedevelop = True
 commands =


### PR DESCRIPTION
This PR adds the rudiments of boolean expressions and some utility functions for working with them.
## Usage examples

The `Var` class wraps a name, and supports disjunction, conjunction and negation:

``` python
>>> from pprint import pprint
>>> from pyreasoner.expressions import *
>>> x = Var('x')
>>> (x & x) | ~x
((x & x) | ~x)
>>> a, b, c = variables('a b c')
>>> ((a & b) | True).reify({a: False, b: True})
((False & True) | True)
>>> expr = a & (b | ~c)
>>> pprint(list(solve_SAT(expr)))
[{a: True, b: True, c: False},
 {a: True, b: True, c: True},
 {a: True, b: False, c: False}]
>>> print([expr.eval(solution) for solution in solve_SAT(expr)])
[True, True, True]
>>> pprint(get_truth_table(expr))
{(False, False, False): False,
 (False, False, True): False,
 (False, True, False): False,
 (False, True, True): False,
 (True, False, False): True,
 (True, False, True): False,
 (True, True, False): True,
 (True, True, True): True}
```

The SAT solver is based on [`pycosat`](https://pypi.python.org/pypi/pycosat) (a python wrapper around the picosat C library). Since that library requires SAT constraints to be passed in as conjunctive normal form, there is a `convert_to_conjunctive_normal_form` method, which will convert an expression to its conjunctive normal form:

```
>>> x1, x2, x3 = variables('x1 x2 x3')
>>> y1, y2, y3 = variables('y1 y2 y3')
>>> expr = (x1 & y1) | (x2 & y2) | (x3 & y3)
>>> cnf = convert_to_conjunctive_normal_form(expr)
>>> print(cnf)
((x3 | x2 | x1) & (y3 | x2 | x1) & (x3 | y2 | x1) & (y3 | y2 | x1) & (x3 | x2 | y1) & (y3 | x2 | y1) & (x3 | y2 | y1) & (y3 | y2 | y1))
>>> assert get_truth_table(expr) == get_truth_table(cnf)
```
